### PR TITLE
Fixed typo

### DIFF
--- a/R/load_standings.R
+++ b/R/load_standings.R
@@ -26,7 +26,7 @@
     suppressMessages() %>%
     dplyr::select(driverId, position,points, wins, constructorId) %>%
     tibble::as_tibble()
-  } else if (type == 'constuctor'){
+  } else if (type == 'constructor'){
     data$MRData$StandingsTable$StandingsLists$ConstructorStandings[[1]] %>%
     tidyr::unnest(cols = c(Constructor)) %>%
     suppressWarnings() %>%


### PR DESCRIPTION
When I ran this function with `type = 'constructor'`, it returned nothing. I noticed there was a very small typo in `load_standings.R`. I changed 'constuctor' to 'constructor'. That fixed it.

Thanks for this nice package! :racing_car: