### PR TITLE
Changed hardcoded current/max season to softcoded

### DIFF
--- a/R/get_driver_telemetry.R
+++ b/R/get_driver_telemetry.R
@@ -3,7 +3,7 @@
 #' Recieves season, race number, driver code, and an optional fastest lap only
 #' argument to output car telemetry for the selected situation.
 #'
-#' @param season number from 2018 to 2022 (defaults to current season).
+#' @param season number from 2018 to current season (defaults to current season).
 #' @param race number from 1 to 23 (depending on season selected) and defaults
 #' to most recent. Also accepts race name.
 #' @param session the code for the session to load Options are FP1, FP2, FP3,
@@ -15,7 +15,7 @@
 #' @return A dataframe with telemetry data for selected driver/session.
 #' @export
 
-get_driver_telemetry <- function(season = 2022, race = 'last', session = 'R', driver, fastest_only = FALSE){
+get_driver_telemetry <- function(season = 'current', race = 'last', session = 'R', driver, fastest_only = FALSE){
   load_race_session('session', season, race, session)
   if(fastest_only){
     tel <- reticulate::py_run_string(glue::glue("tel =session.laps.pick_driver('{driver}').pick_fastest().get_telemetry().add_distance()",

--- a/R/get_driver_telemetry.R
+++ b/R/get_driver_telemetry.R
@@ -7,7 +7,7 @@
 #' @param race number from 1 to 23 (depending on season selected) and defaults
 #' to most recent. Also accepts race name.
 #' @param session the code for the session to load Options are FP1, FP2, FP3,
-#' Q, and R. DEfault is "R", which refers to Race.
+#' Q, S, and R. Default is "R", which refers to Race.
 #' @param driver three letter driver code (see load_drivers() for a list)
 #' @param fastest_only boolean value whether to pick all laps or only the fastest
 #' by the driver in that session.

--- a/R/load_drivers.R
+++ b/R/load_drivers.R
@@ -3,15 +3,15 @@
 #' Loads driver info for all participants in a given season.
 #' This funtion does not export, only the cached version.
 #'
-#' @param season number from 1950 to 2022 (defaults to current season).
+#' @param season number from 1950 to current season (defaults to current season).
 #' @importFrom magrittr "%>%"
 #' @return A dataframe with columns driverId (unique and recurring), first name,
 #' last name, nationality, date of birth (yyyy-mm-dd format), driver code, and
 #' permanent number (for post-2014 drivers).
 
-.load_drivers <- function(season = 2022){
-  if(season != 'current' & (season < 1950 | season > 2022)){
-    stop('Year must be between 1950 and 2022 (or use "current")')
+.load_drivers <- function(season = 'current'){
+  if(season != 'current' & (season < 1950 | season > as.numeric(strftime(Sys.Date(), "%Y")))){
+    stop(glue::glue('Year must be between 1950 and {current} (or use "current")', current=as.numeric(strftime(Sys.Date(), "%Y"))))
   }
   if(season<2014){
     res <-  httr::GET(glue::glue('http://ergast.com/api/f1/{season}/drivers.json?limit=40',
@@ -45,7 +45,7 @@
 #'
 #' Loads driver info for all participants in a given season.
 #'
-#' @param season number from 1950 to 2022 (defaults to current season). All
+#' @param season number from 1950 to current season (defaults to current season). All
 #' drivers after 2014 will have a permanent number.
 #' @return A dataframe with columns driverId (unique and recurring), first name,
 #' last name, nationality, date of birth (yyyy-mm-dd format), driver code, and

--- a/R/load_laps.R
+++ b/R/load_laps.R
@@ -3,7 +3,7 @@
 #' Loads lap-by-lap time data for all drivers in a given season
 #' and round. Lap time data is available from 1996 onwards. This funtion does not export, only the cached version.
 #'
-#' @param season number from 1996 to 2022 (defaults to current season)
+#' @param season number from 1996 to current season (defaults to current season)
 #' @param race number from 1 to 23 (depending on season selected) and defaults
 #' to most recent
 #' @importFrom magrittr "%>%"
@@ -12,8 +12,8 @@
 
 
 .load_laps <- function(season = 'current', race = 'last'){
-  if(season != 'current' & (season < 1996 | season > 2022)){
-    stop('Year must be between 1996 and 2022 (or use "current")')
+  if(season != 'current' & (season < 1996 | season > as.numeric(strftime(Sys.Date(), "%Y")))){
+    stop(glue::glue('Year must be between 1996 and {current} (or use "current")', current=as.numeric(strftime(Sys.Date(), "%Y"))))
   }
     res <-  httr::GET(glue::glue('http://ergast.com/api/f1/{season}/{race}/laps.json?limit=1000',
                     season = season,
@@ -30,7 +30,7 @@
     full <- data$MRData$RaceTable$Races$Laps[[1]][2]
   }
   laps <- tibble::tibble()
-  season_text <-  ifelse(season == 'current', 2022, season)
+  season_text <-  ifelse(season == 'current', as.numeric(strftime(Sys.Date(), "%Y")), season)
   for (i in 1:nrow(full)) {
     laps <- dplyr::bind_rows(laps,
                       full[[1]][i][[1]] %>%
@@ -68,7 +68,7 @@ time_to_sec <- function(time){
 #' Loads lap-by-lap time data for all drivers in a given season
 #' and round. Lap time data is available from 1996 onwards.
 #'
-#' @param season number from 1996 to 2022 (defaults to current season)
+#' @param season number from 1996 to current season (defaults to current season)
 #' @param race number from 1 to 23 (depending on season selected) and defaults
 #' to most recent
 #' @return A dataframe with columns driverId (unique and recurring), position

--- a/R/load_pitstops.R
+++ b/R/load_pitstops.R
@@ -4,7 +4,7 @@
 #' in a season. Pit stop data is available from 2012 onwards.
 #' This funtion does not export, only the cached version.
 #'
-#' @param season number from 2011 to 2022 (defaults to current season).
+#' @param season number from 2011 to current season (defaults to current season).
 #' @param race number from 1 to 23 (depending on season selected) and defaults
 #' to most recent.
 #' @importFrom magrittr "%>%"
@@ -12,8 +12,8 @@
 #' and stop duration
 
 .load_pitstops <- function(season = 'current', race  ='last'){
-  if(season != 'current' & (season < 2011 | season > 2022)){
-    stop('Year must be between 1950 and 2022 (or use "current")')
+  if(season != 'current' & (season < 2011 | season > as.numeric(strftime(Sys.Date(), "%Y")))){
+    stop(glue::glue('Year must be between 1950 and {current} (or use "current")', current=as.numeric(strftime(Sys.Date(), "%Y"))))
   }
   res <-  httr::GET(glue::glue('http://ergast.com/api/f1/{season}/{race}/pitstops.json?limit=80',
                                season = season,
@@ -27,7 +27,7 @@
 #' Loads pit stop info (number, lap, time elapsed) for a given race
 #' in a season. Pit stop data is available from 2012 onwards.
 #'
-#' @param season number from 2012 to 2022 (defaults to current season).
+#' @param season number from 2012 to current season (defaults to current season).
 #' @param race number from 1 to 23 (depending on season selected) and defaults
 #' to most recent.
 #' @return A dataframe with columns

--- a/R/load_quali.R
+++ b/R/load_quali.R
@@ -2,7 +2,7 @@
 #'
 #' Loads qualifying session results for a given season and round.
 #'
-#' @param season number from 1950 to 2022 (defaults to current season).
+#' @param season number from 1950 to current season (defaults to current season).
 #' @param round number from 1 to 23 (depending on season), and defaults
 #' to most recent.
 #' @importFrom magrittr "%>%"
@@ -10,8 +10,8 @@
 #' times in clock format as well as seconds.
 
 .load_quali <- function(season = 'current', round = 'last'){
-   if(season != 'current' & (season < 2003 | season > 2022)){
-    stop('Year must be between 1950 and 2022 (or use "current")')
+   if(season != 'current' & (season < 2003 | season > as.numeric(strftime(Sys.Date(), "%Y")))){
+    stop(glue::glue('Year must be between 1950 and {current} (or use "current")', current=as.numeric(strftime(Sys.Date(), "%Y"))))
    }
   if(season <2006){
     res <-
@@ -57,7 +57,7 @@
 #'
 #' Loads qualifying session results for a given season and round.
 #'
-#' @param season number from 1950 to 2022 (defaults to current season).
+#' @param season number from 1950 to current season (defaults to current season).
 #' @param round number from 1 to 23 (depending on season), and defaults
 #' to most recent.
 #' @importFrom magrittr "%>%"

--- a/R/load_race_session.R
+++ b/R/load_race_session.R
@@ -5,7 +5,7 @@
 #' 2018 onward.
 #'
 #' @param obj_name name assigned to the loaded session to be referenced later.
-#' @param season number from 2018 to 2022 (defaults to current season).
+#' @param season number from 2018 to current season (defaults to current season).
 #' @param race number from 1 to 23 (depending on season selected) and defaults
 #' to most recent. Also accepts race name.
 #' @param session the code for the session to load Options are FP1, FP2, FP3,
@@ -14,9 +14,12 @@
 #' TRUE (recommended), as this lowers subsequent loading times significantly.
 #' @return A session object to be used in other functions.
 
-load_race_session <- function(obj_name, season = 2022, race = 1, session = 'R', cache = T){
-  if(season != 'current' & (season < 2018 | season > 2022)){
+load_race_session <- function(obj_name, season = 'current', race = 1, session = 'R', cache = T){
+  if(season != 'current' & (season < 2018 | season > as.numeric(strftime(Sys.Date(), "%Y")))){
     stop('Year must be between 1950 and 2022 (or use "current")')
+  }
+  if(!(session %in% c("FP1", "FP2", "FP3", "Q", "R", "S"))){
+    stop('Session must be one of "FP1", "FP2", "FP3", "Q", "S", or "R"')
   }
   message("The first time a session is loaded, some time is required. Please be patient. Subsequent times will be faster\n\n")
   reticulate::py_run_string('import fastf1')

--- a/R/load_race_session.R
+++ b/R/load_race_session.R
@@ -16,7 +16,7 @@
 
 load_race_session <- function(obj_name, season = 'current', race = 1, session = 'R', cache = T){
   if(season != 'current' & (season < 2018 | season > as.numeric(strftime(Sys.Date(), "%Y")))){
-    stop('Year must be between 1950 and 2022 (or use "current")')
+    stop(glue::glue('Year must be between 1950 and {current} (or use "current")', current = as.numeric(strftime(Sys.Date(), "%Y"))))
   }
   if(!(session %in% c("FP1", "FP2", "FP3", "Q", "R", "S"))){
     stop('Session must be one of "FP1", "FP2", "FP3", "Q", "S", or "R"')

--- a/R/load_race_session.R
+++ b/R/load_race_session.R
@@ -9,7 +9,7 @@
 #' @param race number from 1 to 23 (depending on season selected) and defaults
 #' to most recent. Also accepts race name.
 #' @param session the code for the session to load Options are FP1, FP2, FP3,
-#' Q, and R. Default is "R", which refers to Race.
+#' Q, S, and R. Default is "R", which refers to Race.
 #' @param cache whether the seesion will get cached or not. Default is set to
 #' TRUE (recommended), as this lowers subsequent loading times significantly.
 #' @return A session object to be used in other functions.

--- a/R/load_results.R
+++ b/R/load_results.R
@@ -2,7 +2,7 @@
 #'
 #' Loads final race resuts for a given year and round.
 #'
-#' @param season number from 1950 to 2022 (defaults to current season).
+#' @param season number from 1950 to current season  (defaults to current season).
 #' @param round number from 1 to 23 (depending on season), and defaults
 #' to most recent.
 #' @importFrom magrittr "%>%"
@@ -11,8 +11,8 @@
 #' fastest lap time, fastest lap in seconds, and top speed in kph.
 
 .load_results <- function(season = 'current', round = 'last'){
-  if(season != 'current' & (season < 1950 | season > 2022)){
-    stop('Year must be between 1950 and 2022 (or use "current")')
+  if(season != 'current' & (season < 1950 | season > as.numeric(strftime(Sys.Date(), "%Y")))){
+    stop(glue::glue('Year must be between 1950 and {current} (or use "current")', current = as.numeric(strftime(Sys.Date(), "%Y"))))
   }
   if(season < 2004){
     res <-  httr::GET(glue::glue(
@@ -53,7 +53,7 @@
 #'
 #' Loads final race resuts for a given year and round.
 #'
-#' @param season number from 1950 to 2022 (defaults to current season).
+#' @param season number from 1950 to current season (defaults to current season).
 #' @param round number from 1 to 23 (depending on season), and defaults
 #' to most recent.
 #' @return A dataframe with columns driverId, grid position, laps completed,

--- a/R/load_schedule.R
+++ b/R/load_schedule.R
@@ -3,15 +3,15 @@
 #' Loads schedule information for a given F1 season.
 #' This funtion does not export, only the cached version.
 #'
-#' @param season number from 1950 to 2022 (defaults to current season).
+#' @param season number from 1950 to current season (defaults to current season).
 #' @importFrom magrittr "%>%"
 #' @return A dataframe with columns season, round, circuitId, circuitName,
 #' latitute and Longitude, locality (city usually), country, date, and time
 #' of the race.
 
-.load_schedule <- function(season = 2022){
-  if(season != 'current' & (season < 1950 | season > 2022)){
-    stop('Year must be between 1950 and 2022 (or use "current")')
+.load_schedule <- function(season = 'current'){
+  if(season != 'current' & (season < 1950 | season > as.numeric(strftime(Sys.Date(), "%Y")))){
+    stop(glue::glue('Year must be between 1950 and {current} (or use "current")', current = as.numeric(strftime(Sys.Date(), "%Y"))))
   } else if(season < 2005){
     res <-
       httr::GET(glue::glue('http://ergast.com/api/f1/{season}.json?limit=30', season = season))
@@ -56,7 +56,7 @@
 #'
 #' Loads schedule information for a given F1 season.
 #'
-#' @param season number from 1950 to 2022 (defaults to current season).
+#' @param season number from 1950 to current season (defaults to current season).
 #' @return A dataframe with columns season, round, circuitId, circuitName,
 #' latitute and Longitude, locality (city usually), country, date, and time
 #' of the race.

--- a/R/load_standings.R
+++ b/R/load_standings.R
@@ -2,7 +2,7 @@
 #'
 #' Loads qualifying session results for a given season and round.
 #'
-#' @param season number from 1950 to 2022 (defaults to current season).
+#' @param season number from 1950 to current season (defaults to current season).
 #' @param round number from 1 to 23 (depending on season), and defaults
 #' to most recent.
 #' @param type select drivers or constructors championship data. Defaluts to
@@ -12,8 +12,8 @@
 #' points, wins and constructorsId in the case of drivers championship.
 
 .load_standings <- function(season = 'current', round = 'last', type = 'driver'){
-  if(season != 'current' & (season < 2003 | season > 2022)){
-    stop('Year must be between 1950 and 2022 (or use "current")')
+  if(season != 'current' & (season < 2003 | season > as.numeric(strftime(Sys.Date(), "%Y")))){
+    stop(glue::glue('Year must be between 1950 and {current} (or use "current")', current=current))
    }
   res <-  httr::GET(glue::glue('http://ergast.com/api/f1/{season}/{round}/{type}Standings.json?limit=40', season = season, round = round, type = type))
   data <- jsonlite::fromJSON(rawToChar(res$content))
@@ -41,7 +41,7 @@
 #'
 #' Loads qualifying session results for a given season and round.
 #'
-#' @param season number from 1950 to 2022 (defaults to current season).
+#' @param season number from 1950 to current season (defaults to current season).
 #' @param round number from 1 to 23 (depending on season), and defaults
 #' to most recent.
 #' #' @param type select drivers or constructors championship data. Defaluts to

--- a/R/plot_fastest.R
+++ b/R/plot_fastest.R
@@ -3,7 +3,7 @@
 #' Creates a ggplot object that details the fastest lap for a driver in a race.
 #' Complete with a gearshift or speed analysis.
 #'
-#' @param season number from 2018 to 2022 (defaults to current season).
+#' @param season number from 2018 to current season (defaults to current season).
 #' @param race number from 1 to 23 (depending on season selected) and defaults
 #' to most recent.
 #' @param session the code for the session to load Options are FP1, FP2, FP3,
@@ -25,7 +25,7 @@ plot_fastest <- function(season = 'current', race = 'last', session = 'R', drive
     dplyr::filter(code == driver) %>%
     dplyr::pull(driverId)
 
-  lap_time <- load_laps(2022, race) %>%
+  lap_time <- load_laps(season, race) %>%
     dplyr::filter(driverId == driver_id) %>%
     dplyr::filter(time_sec == min(.[, 'time_sec'])) %>%
     dplyr::pull(time)

--- a/R/plot_fastest.R
+++ b/R/plot_fastest.R
@@ -7,7 +7,7 @@
 #' @param race number from 1 to 23 (depending on season selected) and defaults
 #' to most recent.
 #' @param session the code for the session to load Options are FP1, FP2, FP3,
-#' Q, and R. DEfault is "R", which refers to Race.
+#' Q, S, and R. Default is "R", which refers to Race.
 #' @param driver three letter driver code (see load_drivers() for a list)
 #' @param color argument that indicates which variable to plot overtop the
 #' circuit

--- a/README.Rmd
+++ b/README.Rmd
@@ -62,7 +62,7 @@ load_laps(2021, 15)
 ### Driver Telemetry
 `get_driver_telemetry(season = 'current', race = 'last', session = 'R', driver, fastest_only = FALSE)`
 
-When the parameters for season (four digit year), race (number or GP name), session (FP1. FP2, FP3, Q or R), and driver code (three letter code) are entered, the function will load all data for a session and the pull the info for the selected driver. The first time a session is called, loading times will be relatively long but in subsequent calls this will improve to only a couple of seconds
+When the parameters for season (four digit year), race (number or GP name), session (FP1. FP2, FP3, Q, S, or R), and driver code (three letter code) are entered, the function will load all data for a session and the pull the info for the selected driver. The first time a session is called, loading times will be relatively long but in subsequent calls this will improve to only a couple of seconds
 
 ```{r}
 get_driver_telemetry(2022, 4, driver = 'PER')

--- a/man/dot-load_drivers.Rd
+++ b/man/dot-load_drivers.Rd
@@ -4,10 +4,10 @@
 \alias{.load_drivers}
 \title{Load Driver Info (not cached)}
 \usage{
-.load_drivers(season = 2022)
+.load_drivers(season = "current")
 }
 \arguments{
-\item{season}{number from 1950 to 2022 (defaults to current season).}
+\item{season}{number from 1950 to current season (defaults to current season).}
 }
 \value{
 A dataframe with columns driverId (unique and recurring), first name,

--- a/man/dot-load_laps.Rd
+++ b/man/dot-load_laps.Rd
@@ -7,7 +7,7 @@
 .load_laps(season = "current", race = "last")
 }
 \arguments{
-\item{season}{number from 1996 to 2022 (defaults to current season)}
+\item{season}{number from 1996 to current season (defaults to current season)}
 
 \item{race}{number from 1 to 23 (depending on season selected) and defaults
 to most recent}

--- a/man/dot-load_pitstops.Rd
+++ b/man/dot-load_pitstops.Rd
@@ -7,7 +7,7 @@
 .load_pitstops(season = "current", race = "last")
 }
 \arguments{
-\item{season}{number from 2011 to 2022 (defaults to current season).}
+\item{season}{number from 2011 to current season (defaults to current season).}
 
 \item{race}{number from 1 to 23 (depending on season selected) and defaults
 to most recent.}

--- a/man/dot-load_quali.Rd
+++ b/man/dot-load_quali.Rd
@@ -7,7 +7,7 @@
 .load_quali(season = "current", round = "last")
 }
 \arguments{
-\item{season}{number from 1950 to 2022 (defaults to current season).}
+\item{season}{number from 1950 to current season (defaults to current season).}
 
 \item{round}{number from 1 to 23 (depending on season), and defaults
 to most recent.}

--- a/man/dot-load_results.Rd
+++ b/man/dot-load_results.Rd
@@ -7,7 +7,7 @@
 .load_results(season = "current", round = "last")
 }
 \arguments{
-\item{season}{number from 1950 to 2022 (defaults to current season).}
+\item{season}{number from 1950 to current season  (defaults to current season).}
 
 \item{round}{number from 1 to 23 (depending on season), and defaults
 to most recent.}

--- a/man/dot-load_schedule.Rd
+++ b/man/dot-load_schedule.Rd
@@ -4,10 +4,10 @@
 \alias{.load_schedule}
 \title{Load Schedule (not cached)}
 \usage{
-.load_schedule(season = 2022)
+.load_schedule(season = "current")
 }
 \arguments{
-\item{season}{number from 1950 to 2022 (defaults to current season).}
+\item{season}{number from 1950 to current season (defaults to current season).}
 }
 \value{
 A dataframe with columns season, round, circuitId, circuitName,

--- a/man/dot-load_standings.Rd
+++ b/man/dot-load_standings.Rd
@@ -7,7 +7,7 @@
 .load_standings(season = "current", round = "last", type = "driver")
 }
 \arguments{
-\item{season}{number from 1950 to 2022 (defaults to current season).}
+\item{season}{number from 1950 to current season (defaults to current season).}
 
 \item{round}{number from 1 to 23 (depending on season), and defaults
 to most recent.}

--- a/man/get_driver_telemetry.Rd
+++ b/man/get_driver_telemetry.Rd
@@ -5,7 +5,7 @@
 \title{Load Telemetry Data for a Driver}
 \usage{
 get_driver_telemetry(
-  season = 2022,
+  season = "current",
   race = "last",
   session = "R",
   driver,
@@ -13,7 +13,7 @@ get_driver_telemetry(
 )
 }
 \arguments{
-\item{season}{number from 2018 to 2022 (defaults to current season).}
+\item{season}{number from 2018 to current season (defaults to current season).}
 
 \item{race}{number from 1 to 23 (depending on season selected) and defaults
 to most recent. Also accepts race name.}

--- a/man/load_drivers.Rd
+++ b/man/load_drivers.Rd
@@ -4,10 +4,10 @@
 \alias{load_drivers}
 \title{Load Driver Info}
 \usage{
-load_drivers(season = 2022)
+load_drivers(season = "current")
 }
 \arguments{
-\item{season}{number from 1950 to 2022 (defaults to current season). All
+\item{season}{number from 1950 to current season (defaults to current season). All
 drivers after 2014 will have a permanent number.}
 }
 \value{

--- a/man/load_laps.Rd
+++ b/man/load_laps.Rd
@@ -7,7 +7,7 @@
 load_laps(season = "current", race = "last")
 }
 \arguments{
-\item{season}{number from 1996 to 2022 (defaults to current season)}
+\item{season}{number from 1996 to current season (defaults to current season)}
 
 \item{race}{number from 1 to 23 (depending on season selected) and defaults
 to most recent}

--- a/man/load_pitstops.Rd
+++ b/man/load_pitstops.Rd
@@ -7,7 +7,7 @@
 load_pitstops(season = "current", race = "last")
 }
 \arguments{
-\item{season}{number from 2012 to 2022 (defaults to current season).}
+\item{season}{number from 2012 to current season (defaults to current season).}
 
 \item{race}{number from 1 to 23 (depending on season selected) and defaults
 to most recent.}

--- a/man/load_quali.Rd
+++ b/man/load_quali.Rd
@@ -7,7 +7,7 @@
 load_quali(season = "current", round = "last")
 }
 \arguments{
-\item{season}{number from 1950 to 2022 (defaults to current season).}
+\item{season}{number from 1950 to current season (defaults to current season).}
 
 \item{round}{number from 1 to 23 (depending on season), and defaults
 to most recent.}

--- a/man/load_race_session.Rd
+++ b/man/load_race_session.Rd
@@ -4,18 +4,24 @@
 \alias{load_race_session}
 \title{Load Session Data}
 \usage{
-load_race_session(obj_name, season = 2022, race = 1, session = "R", cache = T)
+load_race_session(
+  obj_name,
+  season = "current",
+  race = 1,
+  session = "R",
+  cache = T
+)
 }
 \arguments{
 \item{obj_name}{name assigned to the loaded session to be referenced later.}
 
-\item{season}{number from 2018 to 2022 (defaults to current season).}
+\item{season}{number from 2018 to current season (defaults to current season).}
 
 \item{race}{number from 1 to 23 (depending on season selected) and defaults
 to most recent. Also accepts race name.}
 
 \item{session}{the code for the session to load Options are FP1, FP2, FP3,
-Q, and R. DEfault is "R", which refers to Race.}
+Q, and R. Default is "R", which refers to Race.}
 
 \item{cache}{whether the seesion will get cached or not. Default is set to
 TRUE (recommended), as this lowers subsequent loading times significantly.}

--- a/man/load_results.Rd
+++ b/man/load_results.Rd
@@ -7,7 +7,7 @@
 load_results(season = "current", round = "last")
 }
 \arguments{
-\item{season}{number from 1950 to 2022 (defaults to current season).}
+\item{season}{number from 1950 to current season (defaults to current season).}
 
 \item{round}{number from 1 to 23 (depending on season), and defaults
 to most recent.}

--- a/man/load_schedule.Rd
+++ b/man/load_schedule.Rd
@@ -4,10 +4,10 @@
 \alias{load_schedule}
 \title{Load Schedule}
 \usage{
-load_schedule(season = 2022)
+load_schedule(season = "current")
 }
 \arguments{
-\item{season}{number from 1950 to 2022 (defaults to current season).}
+\item{season}{number from 1950 to current season (defaults to current season).}
 }
 \value{
 A dataframe with columns season, round, circuitId, circuitName,

--- a/man/load_standings.Rd
+++ b/man/load_standings.Rd
@@ -7,7 +7,7 @@
 load_standings(season = "current", round = "last", type = "driver")
 }
 \arguments{
-\item{season}{number from 1950 to 2022 (defaults to current season).}
+\item{season}{number from 1950 to current season (defaults to current season).}
 
 \item{round}{number from 1 to 23 (depending on season), and defaults
 to most recent.

--- a/man/plot_fastest.Rd
+++ b/man/plot_fastest.Rd
@@ -13,7 +13,7 @@ plot_fastest(
 )
 }
 \arguments{
-\item{season}{number from 2018 to 2022 (defaults to current season).}
+\item{season}{number from 2018 to current season (defaults to current season).}
 
 \item{race}{number from 1 to 23 (depending on season selected) and defaults
 to most recent.}


### PR DESCRIPTION
Used as.numeric(strftime(Sys.Date(), "%Y")) to determine the current year, so that maximum parameter years are not needing to be updated annually.

I realize this leaves an awkward gap in the January - March(ish) timeframe where the current year doesn't have any valid races yet, but at least this won't require manual package updates each year by each user to get new data.