### PR TITLE
Allow for cache directory to be set by option

### DIFF
--- a/R/clear_f1_cache.R
+++ b/R/clear_f1_cache.R
@@ -1,10 +1,12 @@
 #' Clear f1fastR Cache
 #'
 #' Clears the cache for f1dataR telemetry.
+#' Note that the cache directory can be set by setting `option(f1dataR.cache = [cache dir])`,
+#' but the default is the current working directory.
 #' @export
 
 clear_f1_cache <- function(){
-  reticulate::py_run_string(glue::glue('fastf1.api.Cache.clear_cache("{cache_dir}")',cache_dir = getwd()))
+  reticulate::py_run_string(glue::glue('fastf1.api.Cache.clear_cache("{cache_dir}")', cache_dir = getOption('f1dataR.cache'))
   memoise::forget(f1dataR::load_drivers)
   memoise::forget(f1dataR::load_laps)
   memoise::forget(f1dataR::load_pitstops)

--- a/R/load_race_session.R
+++ b/R/load_race_session.R
@@ -12,6 +12,8 @@
 #' Q, and R. Default is "R", which refers to Race.
 #' @param cache whether the seesion will get cached or not. Default is set to
 #' TRUE (recommended), as this lowers subsequent loading times significantly.
+#' Cache directory can be set by setting `option(f1dataR.cache = [cache dir])`,
+#' default is the current working directory.
 #' @return A session object to be used in other functions.
 
 load_race_session <- function(obj_name, season = 2022, race = 1, session = 'R', cache = T){
@@ -21,7 +23,7 @@ load_race_session <- function(obj_name, season = 2022, race = 1, session = 'R', 
   message("The first time a session is loaded, some time is required. Please be patient. Subsequent times will be faster\n\n")
   reticulate::py_run_string('import fastf1')
   if(cache)
-    reticulate::py_run_string(glue::glue("fastf1.Cache.enable_cache('{wd}')", wd = getwd()))
+    reticulate::py_run_string(glue::glue("fastf1.Cache.enable_cache('{cache_dir}')", cache_dir = getOption('f1dataR.cache')))
   if(is.numeric(race))
     reticulate::py_run_string(glue::glue("{name} = fastf1.get_session({season}, {race}, '{session}')", season = season, race = race, name = obj_name, session = session))
   else

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,3 +5,19 @@
     reticulate::py_install("fastf1", method = 'auto', pip = T)
   # reticulate::import("fastf1", delay_load = TRUE)
 }
+
+.onAttach <- function(){
+  #Load preexisting session/user options
+  op <- options()
+
+  #Make our own lost of options
+  op.package <- list(f1dataR.cache = getwd())
+
+  #IFF our options aren't already set, we'll include those in the new options to write
+  toset <- !(names(op.package) %in% names(op))
+  if(any(toset)) {
+    options(op.package[toset])
+  }
+
+  invisible()
+}


### PR DESCRIPTION
Default will remain the result of getwd(), but users can set a different location to be used as a cache, if desired.