### PR TITLE
Fixes Error during wrapup: Object to convert is not a Python object error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .Rproj.user
 inst/doc
+fastf1_http_cache.sqlite
+*.pkl
+*.ff1pkl


### PR DESCRIPTION
Added a function to recursively, if needed, change the python tel object to a tibble. Fixes #10 

Also added ff1 cache objects to .gitignore, useful if cache is in dev folder (see also #15 for cache location options).