### PR TITLE
Install fixes?

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 Depends: 
     R (>= 2.10),
-    reticulate
+    reticulate (>=1.14)
 Imports:
     glue,
     magrittr,

--- a/R/clear_f1_cache.R
+++ b/R/clear_f1_cache.R
@@ -7,8 +7,10 @@
 
 clear_f1_cache <- function(){
   reticulate::py_run_string(glue::glue('fastf1.api.Cache.clear_cache("{cache_dir}")', cache_dir = getOption('f1dataR.cache'))
-  memoise::forget(f1dataR::load_drivers)
-  memoise::forget(f1dataR::load_laps)
-  memoise::forget(f1dataR::load_pitstops)
-  memoise::forget(f1dataR::load_schedule)
+  if(requireNamespace('memoise', quietly = TRUE)){
+    memoise::forget(f1dataR::load_drivers)
+    memoise::forget(f1dataR::load_laps)
+    memoise::forget(f1dataR::load_pitstops)
+    memoise::forget(f1dataR::load_schedule)
+  }
 }

--- a/R/load_drivers.R
+++ b/R/load_drivers.R
@@ -53,5 +53,5 @@
 
 #' @export
 
-load_drivers <- memoise::memoise(.load_drivers)
+load_drivers <- ifelse(requireNamespace('memoise', quietly = T), memoise::memoise(.load_drivers), .load_drivers)
 

--- a/R/load_laps.R
+++ b/R/load_laps.R
@@ -75,4 +75,4 @@ time_to_sec <- function(time){
 #' during lap, time (in clock form), lap number, time (in seconds), and season.
 #' @export
 
-load_laps <- memoise::memoise(.load_laps)
+load_laps <- ifelse(requireNamespace('memoise', quietly = T), memoise::memoise(.load_laps), .load_laps)

--- a/R/load_pitstops.R
+++ b/R/load_pitstops.R
@@ -33,4 +33,4 @@
 #' @return A dataframe with columns
 #' @export
 
-load_pitstops <- memoise::memoise(.load_pitstops)
+load_pitstops <- ifelse(requireNamespace('memoise', quietly = T), memoise::memoise(.load_pitstops), .load_pitstops)

--- a/R/load_quali.R
+++ b/R/load_quali.R
@@ -65,5 +65,5 @@
 #' times in clock format as well as seconds.
 #' @export
 
-load_quali <- memoise::memoise(.load_quali)
+load_quali <- ifelse(requireNamespace('memoise', quietly = T), memoise::memoise(.load_quali), .load_quali)
 

--- a/R/load_results.R
+++ b/R/load_results.R
@@ -61,5 +61,5 @@
 #' fastest lap time, fastest lap in seconds, and top speed in kph.
 #' @export
 
-load_results <- memoise::memoise(.load_results)
+load_results <- ifelse(requireNamespace('memoise', quietly = T), memoise::memoise(.load_results), .load_results)
 

--- a/R/load_schedule.R
+++ b/R/load_schedule.R
@@ -62,5 +62,5 @@
 #' of the race.
 #' @export
 
-load_schedule <- memoise::memoise(.load_schedule)
+load_schedule <- ifelse(requireNamespace('memoise', quietly = T), memoise::memoise(.load_schedule), .load_schedule)
 

--- a/R/load_standings.R
+++ b/R/load_standings.R
@@ -51,5 +51,5 @@
 #' points, wins and constructorsId in the case of drivers championship.
 #' @export
 
-load_standings <- memoise::memoise(.load_standings)
+load_standings <- ifelse(requireNamespace('memoise', quietly = T), memoise::memoise(.load_standings), .load_standings)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,8 +1,12 @@
 
 .onLoad <- function(libname,pkgname){
   reticulate::configure_environment(pkgname)
-  if(!reticulate::py_module_available('fastf1'))
-    reticulate::py_install("fastf1", method = 'auto', pip = T)
+
+  # This isn't needed after configure_environment is run -
+  # it already installs fastf1 based on the requirements in DESCRIPTION
+  #
+  # if(!reticulate::py_module_available('fastf1'))
+  #   reticulate::py_install("fastf1", method = 'auto', pip = T)
   # reticulate::import("fastf1", delay_load = TRUE)
 }
 


### PR DESCRIPTION
Pull contains two changes - putting memoise behind `requireNamespace` checks (so that it's never invoked if not available) and two reticulate changes - forcing a minimum version (>=1.14) to be able to rely on the `configure_environment` function for fastf1 installation.