### PR TITLE
Updated to enable loading sprint shootouts

### DIFF
--- a/R/get_driver_telemetry.R
+++ b/R/get_driver_telemetry.R
@@ -6,7 +6,7 @@
 #' @param season number from 2018 to current season (defaults to current season).
 #' @param race number from 1 to 23 (depending on season selected). Also accepts race name.
 #' @param session the code for the session to load Options are FP1, FP2, FP3,
-#' Q, S, and R. Default is "R", which refers to Race.
+#' Q, S, SS, and R. Default is "R", which refers to Race.
 #' @param driver three letter driver code (see load_drivers() for a list)
 #' @param fastest_only boolean value whether to pick all laps or only the fastest
 #' by the driver in that session.

--- a/R/load_race_session.R
+++ b/R/load_race_session.R
@@ -13,7 +13,7 @@
 #' @param race number from 1 to 23 (depending on season selected) and defaults
 #' to most recent. Also accepts race name.
 #' @param session the code for the session to load Options are FP1, FP2, FP3,
-#' Q, S, and R. Default is "R", which refers to Race.
+#' Q, S, SS and R. Default is "R", which refers to Race.
 #' Cache directory can be set by setting `option(f1dataR.cache = [cache dir])`,
 #' default is the current working directory.
 #' @param log_level Detail of logging from fastf1 to be displayed. Choice of:
@@ -26,8 +26,8 @@ load_race_session <- function(obj_name="session", season = get_current_season(),
     stop(glue::glue('Year must be between 2018 and {current} (or use "current")',
                     current = get_current_season()))
   }
-  if(!(session %in% c("FP1", "FP2", "FP3", "Q", "R", "S"))){
-    stop('Session must be one of "FP1", "FP2", "FP3", "Q", "S", or "R"')
+  if(!(session %in% c("FP1", "FP2", "FP3", "Q", "R", "S", "SS"))){
+    stop('Session must be one of "FP1", "FP2", "FP3", "Q", "SS", "S", or "R"')
   }
   if(season == 'current'){
     season <- get_current_season()

--- a/R/plot_fastest.R
+++ b/R/plot_fastest.R
@@ -7,7 +7,7 @@
 #' @param race number from 1 to 23 (depending on season selected) and defaults
 #' to most recent.
 #' @param session the code for the session to load Options are FP1, FP2, FP3,
-#' Q, S, and R. Default is "R", which refers to Race.
+#' Q, S, SS, and R. Default is "R", which refers to Race.
 #' @param driver three letter driver code (see load_drivers() for a list)
 #' @param color argument that indicates which variable to plot overtop the
 #' circuit

--- a/README.Rmd
+++ b/README.Rmd
@@ -68,7 +68,7 @@ load_laps(2021, 15)
 ### Driver Telemetry
 `get_driver_telemetry(season = 'current', race = 'last', session = 'R', driver, fastest_only = FALSE)`
 
-When the parameters for season (four digit year), race (number or GP name), session (FP1. FP2, FP3, Q, S, or R), and driver code (three letter code) are entered, the function will load all data for a session and the pull the info for the selected driver. The first time a session is called, loading times will be relatively long but in subsequent calls this will improve to only a couple of seconds
+When the parameters for season (four digit year), race (number or GP name), session (FP1. FP2, FP3, Q, S, SS, or R), and driver code (three letter code) are entered, the function will load all data for a session and the pull the info for the selected driver. The first time a session is called, loading times will be relatively long but in subsequent calls this will improve to only a couple of seconds
 
 ```{r}
 get_driver_telemetry(2022, 4, driver = 'PER')

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ load_laps(2021, 15)
 `get_driver_telemetry(season = 'current', race = 'last', session = 'R', driver, fastest_only = FALSE)`
 
 When the parameters for season (four digit year), race (number or GP
-name), session (FP1. FP2, FP3, Q, S, or R), and driver code (three
+name), session (FP1. FP2, FP3, Q, S, SS, or R), and driver code (three
 letter code) are entered, the function will load all data for a session
 and the pull the info for the selected driver. The first time a session
 is called, loading times will be relatively long but in subsequent calls

--- a/man/get_driver_telemetry.Rd
+++ b/man/get_driver_telemetry.Rd
@@ -19,7 +19,7 @@ get_driver_telemetry(
 \item{race}{number from 1 to 23 (depending on season selected). Also accepts race name.}
 
 \item{session}{the code for the session to load Options are FP1, FP2, FP3,
-Q, S, and R. Default is "R", which refers to Race.}
+Q, S, SS, and R. Default is "R", which refers to Race.}
 
 \item{driver}{three letter driver code (see load_drivers() for a list)}
 

--- a/man/load_race_session.Rd
+++ b/man/load_race_session.Rd
@@ -21,7 +21,7 @@ load_race_session(
 to most recent. Also accepts race name.}
 
 \item{session}{the code for the session to load Options are FP1, FP2, FP3,
-Q, S, and R. Default is "R", which refers to Race.
+Q, S, SS and R. Default is "R", which refers to Race.
 Cache directory can be set by setting \verb{option(f1dataR.cache = [cache dir])},
 default is the current working directory.}
 

--- a/man/plot_fastest.Rd
+++ b/man/plot_fastest.Rd
@@ -13,7 +13,7 @@ plot_fastest(season = 2022, race = 1, session = "R", driver, color = "gear")
 to most recent.}
 
 \item{session}{the code for the session to load Options are FP1, FP2, FP3,
-Q, S, and R. Default is "R", which refers to Race.}
+Q, S, SS, and R. Default is "R", which refers to Race.}
 
 \item{driver}{three letter driver code (see load_drivers() for a list)}
 

--- a/tests/testthat/test-load_race_session.R
+++ b/tests/testthat/test-load_race_session.R
@@ -47,7 +47,7 @@ test_that("Load Session Works", {
   expect_error(load_race_session(season = 2017),
                "Year must be between 2018 and *")
   expect_error(load_race_session(session = "ZZZ"),
-               'Session must be one of "FP1", "FP2", "FP3", "Q", "S", or "R"')
+               'Session must be one of "FP1", "FP2", "FP3", "Q", "SS", "S", or "R"')
   expect_error(load_race_session('session', season = 2022, race = 1, session = "R", log_level = "ZZZ"))
   #expect_message(load_race_session('session', season = 2022, race = 1, session = "R", log_level = 'INFO'),
   #               regexp = NULL) # This type of check is set up to later possibly handle verbose = FALSE/TRUE option tests


### PR DESCRIPTION
2023 includes 'sprint shootout' sessions (quali for sprint races). This update enables loading them through the load_race_session function and updates related documentation