### PR TITLE
Telemetry updates to fix NA Time - but discuss lap picking?

### DIFF
--- a/.github/workflows/check-multipython.yaml
+++ b/.github/workflows/check-multipython.yaml
@@ -1,0 +1,66 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check-oldff1
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}/
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }}) old fastf1
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - name: setup r-reticulate venv
+        shell: Rscript {0}
+        run: |
+          python_packages <- c("numpy", "fastf1")
+
+          library(reticulate)
+          virtualenv_create("r-reticulate", Sys.which("python"))
+          virtualenv_install("r-reticulate", python_packages)
+
+          path_to_python <- virtualenv_python("r-reticulate")
+          writeLines(sprintf("RETICULATE_PYTHON=%s", path_to_python),
+                     Sys.getenv("GITHUB_ENV"))
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/R/load_driver_telemetry.R
+++ b/R/load_driver_telemetry.R
@@ -18,23 +18,28 @@
 #' @import reticulate
 #' @export
 
-
-load_driver_telemtery <- function(season = get_current_season, round =1, session = 'R', driver, fastest_only = FALSE, log_level="WARNING", race = lifecycle::deprecated()){
+load_driver_telemetry <- function(season = get_current_season, round =1, session = 'R', driver, fastest_only = FALSE, log_level="WARNING", race = lifecycle::deprecated()){
   if (lifecycle::is_present(race)) {
     lifecycle::deprecate_warn("0.4.1", "load_driver_telemtery(race)", "load_driver_telemtery(round)")
     round <- race
   }
   load_race_session("session", season = season, round = round, session = session, log_level = log_level)
   if(fastest_only){
-    tel <- reticulate::py_run_string(glue::glue("tel =session.laps.pick_driver('{driver}').pick_fastest().get_telemetry().add_distance()",
+    reticulate::py_run_string(glue::glue("tel = session.laps.pick_driver('{driver}').pick_fastest().get_telemetry().add_distance()",
                                                 driver = driver))
-    res <- py_tel_to_tibble(tel)
+
   }else{
-    tel <- reticulate::py_run_string(glue::glue("tel =session.laps.pick_driver('{driver}').get_telemetry().add_distance()",
+    reticulate::py_run_string(glue::glue("tel = session.laps.pick_driver('{driver}').get_telemetry().add_distance()",
                                                 driver = driver))
-    res <- py_tel_to_tibble(tel)
+
   }
-  res %>%
+  py_env <- reticulate::py_run_string(paste("tel.SessionTime = tel.SessionTime.dt.total_seconds()",
+                                  "tel.Time = tel.Time.dt.total_seconds()",
+                                  sep = "\n"))
+
+  tel <- reticulate::py_to_r(reticulate::py_get_item(py_env, 'tel'))
+
+  tel %>%
     dplyr::mutate(driverCode = driver) %>%
     tibble::tibble() %>%
     janitor::clean_names()

--- a/tests/testthat/test-load_driver_telemetry.R
+++ b/tests/testthat/test-load_driver_telemetry.R
@@ -22,12 +22,9 @@ test_that("driver telemetry", {
   telem <- load_driver_telemtery(season = 2022, round = "Brazil", session = "S", driver = "HAM")
   telem_fast <- load_driver_telemtery(season = 2022, round = "Brazil", session = "S", driver = "HAM", fastest_only = T)
 
-  expect_true(all(telem_fast$time %in% telem$time))
-
   expect_true(nrow(telem) > nrow(telem_fast))
   expect_true(ncol(telem) == ncol(telem_fast))
-
-  # expect_message(load_driver_telemtery(season = 2022, race = "Brazil", session = "S", driver = "HAM"),
-  #                regexp = NULL) # This itype of check is set up to later possibly handle verbose = FALSE/TRUE option tests
+  expect_equal(telem_fast$session_time[[1]], 3518.641)
+  expect_equal(telem_fast$time[[2]],0.086)
 
 })


### PR DESCRIPTION
Fixes #71 

Note that we might want to change how we let the user pick laps. Right now it's just 'fastest_only' T/F, but if we use 'laps' as an arguement we could accept 'fastest', 'all', or a numbered range (likely 'fastest' as default).

If a numbered range is provided, there is a function in fastf1 for that (https://docs.fastf1.dev/core.html#fastf1.core.Telemetry.slice_by_lap). Note once the data is in R there's no figuring out what lap it is so the user has to make that choice early.