### PR TITLE
Introduce better error messages using `{cli}`

### DIFF
--- a/R/load_circuits.R
+++ b/R/load_circuits.R
@@ -10,8 +10,9 @@
 
 .load_circuits <- function(season = 'current'){
   if(season != 'current' & (season < 1950 | season > get_current_season())){
-    stop(glue::glue('Year must be between 1950 and {current} (or use "current")',
-                    current=get_current_season()))
+    cli::cli_abort('{.var season} must be between 1950 and {get_current_season()} (or use "current")')
+    # stop(glue::glue('Year must be between 1950 and {current} (or use "current")',
+    #                 current=get_current_season()))
   }
 
   url <- glue::glue('{season}/circuits.json?limit=40',

--- a/R/load_driver_telemetry.R
+++ b/R/load_driver_telemetry.R
@@ -20,7 +20,7 @@
 
 load_driver_telemetry <- function(season = get_current_season, round =1, session = 'R', driver, fastest_only = FALSE, log_level="WARNING", race = lifecycle::deprecated()){
   if (lifecycle::is_present(race)) {
-    lifecycle::deprecate_warn("0.4.1", "load_driver_telemetry(race)", "load_driver_telemetry(round)")
+    lifecycle::deprecate_warn("1.0.0", "load_driver_telemetry(race)", "load_driver_telemetry(round)")
     round <- race
   }
   load_race_session("session", season = season, round = round, session = session, log_level = log_level)
@@ -65,6 +65,6 @@ load_driver_telemetry <- function(season = get_current_season, round =1, session
 
 
 get_driver_telemetry <- function(season = get_current_season(), round =1, session = 'R', driver, fastest_only = FALSE, log_level="WARNING", race = lifecycle::deprecated()){
-  lifecycle::deprecate_warn("0.4.1", "get_driver_telemetry()", "load_driver_telemetry()")
+  lifecycle::deprecate_warn("1.0.0", "get_driver_telemetry()", "load_driver_telemetry()")
   load_driver_telemetry(season = season, round = round, session = session, driver = driver, fastest_only = fastest_only, log_level = log_level, race = race)
 }

--- a/R/load_drivers.R
+++ b/R/load_drivers.R
@@ -12,8 +12,9 @@
 
 .load_drivers <- function(season = 'current'){
   if(season != 'current' & (season < 1950 | season > get_current_season())){
-    stop(glue::glue('Year must be between 1950 and {current} (or use "current")',
-                    current=get_current_season()))
+    cli::cli_abort('{.var season} must be between 1950 and {get_current_season()} (or use "current")')
+    # stop(glue::glue('Year must be between 1950 and {current} (or use "current")',
+    #                 current=get_current_season()))
   }
 
   url <- glue::glue('{season}/drivers.json?limit=40',

--- a/R/load_laps.R
+++ b/R/load_laps.R
@@ -20,8 +20,9 @@
     round <- race
   }
   if(season != 'current' & (season < 1996 | season > get_current_season())){
-    stop(glue::glue('Year must be between 1996 and {current} (or use "current")',
-                    current=get_current_season()))
+    cli::cli_abort('{.var season} must be between 1996 and {get_current_season()} (or use "current")')
+    # stop(glue::glue('Year must be between 1996 and {current} (or use "current")',
+    #                 current=get_current_season()))
   }
 
   url <- glue::glue('{season}/{round}/laps.json?limit=1000',

--- a/R/load_pitstops.R
+++ b/R/load_pitstops.R
@@ -20,8 +20,9 @@
     round <- race
   }
   if(season != 'current' & (season < 2011 | season > get_current_season())){
-    stop(glue::glue('Year must be between 1950 and {current} (or use "current")',
-                    current=get_current_season()))
+    cli::cli_abort('{.var season} must be between 1950 and {get_current_season()} (or use "current")')
+    # stop(glue::glue('Year must be between 1950 and {current} (or use "current")',
+    #                 current=get_current_season()))
   }
 
   url <- glue::glue('{season}/{round}/pitstops.json?limit=80',

--- a/R/load_quali.R
+++ b/R/load_quali.R
@@ -12,8 +12,9 @@
 
 .load_quali <- function(season = 'current', round = 'last'){
    if(season != 'current' & (season < 2003 | season > get_current_season())){
-    stop(glue::glue('Year must be between 2003 and {current} (or use "current")',
-                    current=get_current_season()))
+     cli::cli_abort('{.var season} must be between 2003 and {get_current_season()} (or use "current")')
+    # stop(glue::glue('Year must be between 2003 and {current} (or use "current")',
+    #                 current=get_current_season()))
    }
 
   url <- glue::glue('{season}/{round}/qualifying.json?limit=40',

--- a/R/load_race_session.R
+++ b/R/load_race_session.R
@@ -30,11 +30,13 @@ load_race_session <- function(obj_name="session", season = get_current_season(),
     round <- race
   }
   if(season != 'current' & (season < 2018 | season > get_current_season())){
-    stop(glue::glue('Year must be between 2018 and {current} (or use "current")',
-                    current = get_current_season()))
+    cli::cli_abort('{.var season} must be between 2018 and {get_current_season()} (or use "current")')
+    # stop(glue::glue('Year must be between 2018 and {current} (or use "current")',
+    #                 current = get_current_season()))
   }
   if(!(session %in% c("FP1", "FP2", "FP3", "Q", "R", "S", "SS"))){
-    stop('Session must be one of "FP1", "FP2", "FP3", "Q", "SS", "S", or "R"')
+    cli::cli_abort('{.var session} must be one of "FP1", "FP2", "FP3", "Q", "SS", "S", or "R"')
+    # stop('Session must be one of "FP1", "FP2", "FP3", "Q", "SS", "S", or "R"')
   }
   if(season == 'current'){
     season <- get_current_season()

--- a/R/load_results.R
+++ b/R/load_results.R
@@ -12,8 +12,9 @@
 
 .load_results <- function(season = 'current', round = 'last'){
   if(season != 'current' & (season < 1950 | season > get_current_season())){
-    stop(glue::glue('Year must be between 1950 and {current} (or use "current")',
-                    current = get_current_season()))
+    cli::cli_abort('{.var season} must be between 1950 and {get_current_season()} (or use "current")')
+    # stop(glue::glue('Year must be between 1950 and {current} (or use "current")',
+    #                 current = get_current_season()))
   }
 
   url <- glue::glue('{season}/{round}/results.json?limit=40',

--- a/R/load_schedule.R
+++ b/R/load_schedule.R
@@ -10,8 +10,9 @@
 
 .load_schedule <- function(season = 'current'){
   if(season != 'current' & (season < 1950 | season > get_current_season())){
-    stop(glue::glue('Year must be between 1950 and {current} (or use "current")',
-                    current = get_current_season()))
+    cli::cli_abort('{.var season} must be between 2003 and {get_current_season()} (or use "current")')
+    # stop(glue::glue('Year must be between 1950 and {current} (or use "current")',
+    #                 current = get_current_season()))
   }
 
   url <- glue::glue('{season}.json?limit=30', season = season)

--- a/R/load_sprint.R
+++ b/R/load_sprint.R
@@ -16,8 +16,9 @@
 
 .load_sprint <- function(season = 'current', round = 'last'){
   if(season != 'current' & (season < 2021 | season > get_current_season())){
-    stop(glue::glue('Year must be between 2021 and {current} (or use "current")',
-                    current = get_current_season()))
+    cli::cli_abort('{.var season} must be between 2021 and {get_current_season()} (or use "current")')
+    # stop(glue::glue('Year must be between 2021 and {current} (or use "current")',
+    #                 current = get_current_season()))
   }
 
   url <- glue::glue('{season}/{round}/sprint.json?limit=40',

--- a/R/load_standings.R
+++ b/R/load_standings.R
@@ -15,8 +15,9 @@
 
 .load_standings <- function(season = 'current', round = 'last', type = 'driver'){
   if(season != 'current' & (season < 2003 | season > get_current_season())){
-    stop(glue::glue('Year must be between 1950 and {current} (or use "current")',
-                    current=get_current_season()))
+    cli::cli_abort('{.var season} must be between 2003 and {get_current_season()} (or use "current")')
+    # stop(glue::glue('Year must be between 1950 and {current} (or use "current")',
+    #                 current=get_current_season()))
   }
 
   url <- glue::glue('{season}/{round}/{type}Standings.json?limit=40',


### PR DESCRIPTION
Replace `stop()` calls with `cli::cli_abort()` as suggested by the tidyverse style guide (https://style.tidyverse.org/error-messages.html). Minor fixes