### PR TITLE
Remove deprecated `fastest_only` from examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,11 +4,15 @@ Version: 1.1.0
 Authors@R: 
     c(person(given = "Santiago",
            family = "Casanova",
-           role = c("aut", "cre"),
+           role = c("aut", "cre", "cph"),
            email = "santiago.casanova@yahoo.com"),
-    person(given = "Philip", family = "Bulsink", role = "aut", email = "bulsinkp@gmail.com"))
-Description: A collection of functions that wrap Ergast API Formula 1 data and F1 official data via the fastf1 python library. 
-Config/reticulate: 
+    person(given = "Philip", 
+          family = "Bulsink", 
+          role = "aut", 
+          email = "bulsinkp@gmail.com"))
+Description: A collection of functions that wrap Ergast API Formula 1 data and 
+      F1 official data via the fastf1 python library. 
+Config/reticulate:
   list(
     packages = list(
       list(package = "fastf1", pip = TRUE)

--- a/R/load_driver_telemetry.R
+++ b/R/load_driver_telemetry.R
@@ -106,7 +106,8 @@ load_driver_telemetry <- function(season = get_current_season(), round = 1, sess
 #' consistent API.
 #' @keywords internal
 #' @export
-get_driver_telemetry <- function(season = get_current_season(), round =1, session = 'R', driver, fastest_only = FALSE, log_level="WARNING", race = lifecycle::deprecated()){
+
+get_driver_telemetry <- function(season = get_current_season(), round = 1, session = 'R', driver, laps = 'fastest', log_level = "WARNING", race = lifecycle::deprecated(), fastest_only = lifecycle::deprecated()){
   lifecycle::deprecate_warn("1.0.0", "get_driver_telemetry()", "load_driver_telemetry()")
-  load_driver_telemetry(season = season, round = round, session = session, driver = driver, fastest_only = fastest_only, log_level = log_level, race = race)
+  load_driver_telemetry(season = season, round = round, session = session, driver = driver, laps = laps, log_level = log_level, race = race, fastest_only = fastest_only)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -70,14 +70,14 @@ load_laps(2021, 15)
 
 
 ### Driver Telemetry
-`load_driver_telemetry(season = 'current', race = 'last', session = 'R', driver, fastest_only = FALSE)`
+`load_driver_telemetry(season = 'current', race = 'last', session = 'R', driver, laps = "all")`
 
 When the parameters for season (four digit year), round (number or GP name), session (FP1. FP2, FP3, Q, S, SS, or R), and driver code (three letter code) are entered, the function will load all data for a session and the pull the info for the selected driver. The first time a session is called, loading times will be relatively long but in subsequent calls this will improve to only a couple of seconds
 
 ```{r}
 load_driver_telemetry(2022, round = 4, driver = 'PER')
 
-load_driver_telemetry(2018, round = 7,'Q', 'HAM', fastest_only = T)
+load_driver_telemetry(2018, round = 7,'Q', 'HAM', laps = "fastest")
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ load_laps(2021, 15)
 
 ### Driver Telemetry
 
-`load_driver_telemetry(season = 'current', race = 'last', session = 'R', driver, fastest_only = FALSE)`
+`load_driver_telemetry(season = 'current', race = 'last', session = 'R', driver, laps = "fastest")`
 
 When the parameters for season (four digit year), round (number or GP
 name), session (FP1. FP2, FP3, Q, S, SS, or R), and driver code (three
@@ -113,7 +113,7 @@ load_driver_telemetry(2022, round = 4, driver = 'PER')
 #> #   distance <dbl>, driver_ahead <chr>, distance_to_driver_ahead <dbl>,
 #> #   driver_code <chr>, and abbreviated variable name ¹​throttle
 
-load_driver_telemetry(2018, round = 7,'Q', 'HAM', fastest_only = T)
+load_driver_telemetry(2018, round = 7,'Q', 'HAM', laps = 'fastest')
 #> # A tibble: 534 × 19
 #>    date                session_time  time   rpm speed n_gear throt…¹ brake   drs
 #>    <dttm>                     <dbl> <dbl> <dbl> <dbl>  <dbl>   <dbl> <lgl> <dbl>

--- a/docs/index.html
+++ b/docs/index.html
@@ -156,7 +156,7 @@
 <div class="section level3">
 <h3 id="driver-telemetry">Driver Telemetry<a class="anchor" aria-label="anchor" href="#driver-telemetry"></a>
 </h3>
-<p><code>load_driver_telemetry(season = 'current', race = 'last', session = 'R', driver, fastest_only = FALSE)</code></p>
+<p><code>load_driver_telemetry(season = 'current', race = 'last', session = 'R', driver, laps = "fastest")</code></p>
 <p>When the parameters for season (four digit year), round (number or GP name), session (FP1. FP2, FP3, Q, S, SS, or R), and driver code (three letter code) are entered, the function will load all data for a session and the pull the info for the selected driver. The first time a session is called, loading times will be relatively long but in subsequent calls this will improve to only a couple of seconds</p>
 <div class="sourceCode" id="cb4"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="fu"><a href="reference/load_driver_telemetry.html">load_driver_telemetry</a></span><span class="op">(</span><span class="fl">2022</span>, round <span class="op">=</span> <span class="fl">4</span>, driver <span class="op">=</span> <span class="st">'PER'</span><span class="op">)</span></span>
@@ -178,7 +178,7 @@
 <span><span class="co">#&gt; #   distance &lt;dbl&gt;, driver_ahead &lt;chr&gt;, distance_to_driver_ahead &lt;dbl&gt;,</span></span>
 <span><span class="co">#&gt; #   driver_code &lt;chr&gt;, and abbreviated variable name ¹​throttle</span></span>
 <span></span>
-<span><span class="fu"><a href="reference/load_driver_telemetry.html">load_driver_telemetry</a></span><span class="op">(</span><span class="fl">2018</span>, round <span class="op">=</span> <span class="fl">7</span>,<span class="st">'Q'</span>, <span class="st">'HAM'</span>, fastest_only <span class="op">=</span> <span class="cn">T</span><span class="op">)</span></span>
+<span><span class="fu"><a href="reference/load_driver_telemetry.html">load_driver_telemetry</a></span><span class="op">(</span><span class="fl">2018</span>, round <span class="op">=</span> <span class="fl">7</span>,<span class="st">'Q'</span>, <span class="st">'HAM'</span>, laps <span class="op">=</span> <span class="st">'fastest'</span><span class="op">)</span></span>
 <span><span class="co">#&gt; # A tibble: 534 × 19</span></span>
 <span><span class="co">#&gt;    date                session_time  time   rpm speed n_gear throt…¹ brake   drs</span></span>
 <span><span class="co">#&gt;    &lt;dttm&gt;                     &lt;dbl&gt; &lt;dbl&gt; &lt;dbl&gt; &lt;dbl&gt;  &lt;dbl&gt;   &lt;dbl&gt; &lt;lgl&gt; &lt;dbl&gt;</span></span>
@@ -255,7 +255,7 @@
 </h2>
 <p>The package also includes a static data frame for all current drivers and their respective constructors. Complete with team colors, logo and driver number logo.</p>
 <div class="sourceCode" id="cb7"><pre class="downlit sourceCode r">
-<code class="sourceCode R"><span><span class="va">constructor_data</span> <span class="op">%&gt;%</span> <span class="fu"><a href="https://rdrr.io/r/base/colnames.html" class="external-link">colnames</a></span><span class="op">(</span><span class="op">)</span></span>
+<code class="sourceCode R"><span><span class="va">constructor_data</span> <span class="op"><a href="https://magrittr.tidyverse.org/reference/pipe.html" class="external-link">%&gt;%</a></span> <span class="fu"><a href="https://rdrr.io/r/base/colnames.html" class="external-link">colnames</a></span><span class="op">(</span><span class="op">)</span></span>
 <span><span class="co">#&gt; [1] "constructor_id"     "constructor_color"  "constructor_color2"</span></span>
 <span><span class="co">#&gt; [4] "constructor_logo"</span></span></code></pre></div>
 </div>

--- a/man/get_driver_telemetry.Rd
+++ b/man/get_driver_telemetry.Rd
@@ -9,9 +9,10 @@ get_driver_telemetry(
   round = 1,
   session = "R",
   driver,
-  fastest_only = FALSE,
+  laps = "fastest",
   log_level = "WARNING",
-  race = lifecycle::deprecated()
+  race = lifecycle::deprecated(),
+  fastest_only = lifecycle::deprecated()
 )
 }
 \arguments{
@@ -24,13 +25,16 @@ get_driver_telemetry(
 
 \item{driver}{three letter driver code (see \code{load_drivers()} for a list)}
 
-\item{fastest_only}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} \code{fastest_only} is no longer supported, indicated preferred
-laps in \code{laps}.}
+\item{laps}{which lap's telemetry to return. One of an integer lap number (<= total laps in the race), \code{fastest},
+or \code{all}. Note that integer lap choice requires \code{fastf1} version 3.0 or greater.}
 
 \item{log_level}{Detail of logging from fastf1 to be displayed. Choice of:
 \code{'DEBUG'}, \code{'INFO'}, \code{'WARNING'}, \code{'ERROR'} and \code{'CRITICAL'}. See \href{https://theoehrly.github.io/Fast-F1/fastf1.html#configure-logging-verbosity}{fastf1 documentation}.}
 
 \item{race}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} \code{race} is no longer supported, use \code{round}.}
+
+\item{fastest_only}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} \code{fastest_only} is no longer supported, indicated preferred
+laps in \code{laps}.}
 }
 \value{
 A tibble with telemetry data for selected driver/session.

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -34,7 +34,7 @@ Let's get Leclerc's fastest lap from the first race of 2022:
 ```{r telem}
 library(f1dataR)
 
-load_driver_telemetry(2022, 1, driver = 'LEC', fastest_only = T)
+load_driver_telemetry(2022, 1, driver = 'LEC', laps = "fastest")
 ```
 
 Now let's use ggplot2 to visualize some of the data we have
@@ -43,7 +43,7 @@ Now let's use ggplot2 to visualize some of the data we have
 library(dplyr)
 library(ggplot2)
 
-lec <- load_driver_telemetry(2022, 1, driver = 'LEC', fastest_only = T) %>% 
+lec <- load_driver_telemetry(2022, 1, driver = 'LEC', laps = "fastest") %>% 
   head(300)
 
 ggplot(lec, aes(distance, throttle))+
@@ -54,10 +54,10 @@ ggplot(lec, aes(distance, throttle))+
 What if we get more drivers involved. Let's also get the Qualifying data from Hamilton and Perez
 
 ```{r triple_plot}
-ham <- load_driver_telemetry(2022, 1, 'Q', driver = 'HAM', fastest_only = T) %>% 
+ham <- load_driver_telemetry(2022, 1, 'Q', driver = 'HAM', laps = "fastest") %>% 
   head(300)
 
-per <- load_driver_telemetry(2022, 1, driver = 'PER', fastest_only = T) %>% 
+per <- load_driver_telemetry(2022, 1, driver = 'PER', laps = "fastest") %>% 
   head(300)
 
 data <- bind_rows(lec,ham,per)
@@ -130,7 +130,7 @@ Now let's visualize the portion of the track where Verstappen had the throttle 1
 ver_can <- load_driver_telemetry(season = 2023, 
                                  round = 'Canada', 
                                  driver = 'VER',
-                                 fastest_only = T) %>% 
+                                 laps = "fastest") %>% 
   mutate(open_throttle = ifelse(throttle == 100, 'Yes', "No"))
 
 ggplot(ver_can, aes(x, y, color = as.factor(open_throttle), group = NA)) +


### PR DESCRIPTION
Replaced the deprecated argument `fastest_only` from vignettes and examples. Also slightly modified `DESCRIPTION` for CRAN purposes