### PR TITLE
New Version + normalize path for memory cache

### DIFF
--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,3 @@
-Version: 1.2.1
-Date: 2023-08-10 13:25:11 UTC
-SHA: ff92e485d9e4b1202fcf75b026b26b0167fa75e7
+Version: 1.3.0
+Date: 2023-08-16 15:46:11 UTC
+SHA: f844788ec6e3fb67320a2733ec97e7de6ebd0f9f

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: f1dataR
 Title: Access Formula 1 Data
-Version: 1.2.1
+Version: 1.3.0
 Authors@R: c(
     person("Santiago", "Casanova", , "santiago.casanova@yahoo.com", role = c("aut", "cre", "cph")),
     person("Philip", "Bulsink", , "bulsinkp@gmail.com", role = "aut",

--- a/R/load_race_session.R
+++ b/R/load_race_session.R
@@ -59,7 +59,7 @@ load_race_session <- function(obj_name = "session", season = get_current_season(
 
   # only cache to tempdir if cache option is set to memory or off (includes filesystem in vector as a fallback error catch)
   if (getOption("f1dataR.cache") %in% c("memory", "off", "filesystem")) {
-    f1datar_cache <- tempdir()
+    f1datar_cache <- normalizePath(tempdir(), winslash = "/")
   } else {
     f1datar_cache <- normalizePath(getOption("f1dataR.cache"), winslash = "/")
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -110,22 +110,24 @@
   }
 
   if (!memoise_option %in% c("memory", "filesystem", "off") && !dir.exists(normalizePath(memoise_option, mustWork = FALSE))) {
-    cli::cli_alert_info(
-    # packageStartupMessage(
-      "Note: f1dataR.cache is set to '{memoise_option}' and should be one of c('memory','filesystem', 'off') or a filepath.Defaulting to 'memory'."
+    packageStartupMessage(
+      "Note: f1dataR.cache is set to '",
+      memoise_option,
+      "' and should be one of c('memory','filesystem', 'off') or a filepath. \n",
+      "Defaulting to 'memory'."
     )
     options("f1dataR.cache" = "memory")
   }
 
   if (memoise_option != "off") {
-    cli::cli_alert_info(
-    # packageStartupMessage(
-      "Note: f1dataR will cache for up to 24 hours, or until the end of the R session."
+    packageStartupMessage(
+      "Note: f1dataR will cache for up to 24 hours, \n",
+      "or until the end of the R session."
     )
   } else {
-    cli::cli_alert_info(
-    # packageStartupMessage(
-      "Note: f1dataR.cache is set to 'off'. Session specific FastF1 functions will still cache to discardable temporary directory."
+    packageStartupMessage(
+      "Note: f1dataR.cache is set to 'off' \n",
+      "Session specific FastF1 functions will still cache to discardable temporary directory."
     )
   }
 }


### PR DESCRIPTION
Update to 1.3 version + normalize with proper winslash on `load_race_session()` cache (memory option)