### PR TITLE
Removing tagged packages from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,13 +24,10 @@ Depends:
 Imports: 
     glue,
     magrittr,
-    tibble,
     jsonlite,
     httr2,
     memoise,
-    janitor,
     dplyr,
-    tidyr,
     rlang,
     lifecycle,
     cli,


### PR DESCRIPTION
Weird build notes exist usually after R CMD Check identifying `tibble`, `janitor`, and `tidyr` as unneeded imports. I don't believe this, since they're used in the package, but I'm checking the full build stack in this PR.