### PR TITLE
Fixing GH Actions

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -46,6 +46,10 @@ jobs:
         with:
           python-version: ${{ matrix.config.py }}
 
+      - name: setup python3-venv
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install python3-venv
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -27,6 +27,9 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: setup python3-venv
+        run: sudo apt-get install python3-venv
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::covr


### PR DESCRIPTION
Working on #187 - It looks like `reticulate` requires that `sudo apt-get install python3-venv` be explicitly called at some point - see rstudio/reticulate#1437