### PR TITLE
Use package_version

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -162,7 +162,7 @@ check_ff1_session_loaded <- function(session_name = "session") {
 #' @keywords internal
 check_ff1_version <- function() {
   version <- get_fastf1_version()
-  if (version$major < 3 | (version$major == 3 & version$minor < 1)) {
+  if (version < '3.1') {
     cli::cli_abort(c("An old version of {.pkg FastF1} is in use. {.pkg f1dataR} requires {.pkg FastF1} version 3.1.0 or newer.",
       x = "Support for older {.pkg FastF1} versions was removed in {.pkg f1dataR} v1.6.0",
       i = "You can update your {.pkg FastF1} installation by running: {.code reticulate::py_install('fastf1')}"
@@ -179,7 +179,7 @@ check_ff1_version <- function() {
 #' Gets the current installed FastF1 version available (via `reticulate`) to the function.
 #' Displays a note if significantly out of date.
 #' @export
-#' @return integer for major version number (or NA if any error )
+#' @return version as class `package_version`
 get_fastf1_version <- function() {
   ver <- reticulate::py_list_packages() %>%
     dplyr::filter(.data$package == "fastf1") %>%
@@ -188,10 +188,8 @@ get_fastf1_version <- function() {
     cli::cli_warn("Ensure {.pkg fastf1} Python package is installed.\nPlease run this to install the most recent version:\n{.code setup_fastf1()}")
     return(NA)
   }
-  major <- as.integer(unlist(strsplit(ver, ".", fixed = T))[1])
-  minor <- as.integer(unlist(strsplit(ver, ".", fixed = T))[2])
 
-  return(list(major = major, minor = minor))
+  return(package_version(ver))
 }
 
 # nocov start

--- a/R/utils.R
+++ b/R/utils.R
@@ -162,7 +162,7 @@ check_ff1_session_loaded <- function(session_name = "session") {
 #' @keywords internal
 check_ff1_version <- function() {
   version <- get_fastf1_version()
-  if (version < '3.1') {
+  if (version < "3.1") {
     cli::cli_abort(c("An old version of {.pkg FastF1} is in use. {.pkg f1dataR} requires {.pkg FastF1} version 3.1.0 or newer.",
       x = "Support for older {.pkg FastF1} versions was removed in {.pkg f1dataR} v1.6.0",
       i = "You can update your {.pkg FastF1} installation by running: {.code reticulate::py_install('fastf1')}"

--- a/tests/testthat/test-load_circuit_details.R
+++ b/tests/testthat/test-load_circuit_details.R
@@ -14,7 +14,7 @@ test_that("load circuit details works", {
 
   # Ensure failure if old ff1, then skip
   ff1_ver <- get_fastf1_version()
-  if (ff1_ver < '3.1') {
+  if (ff1_ver < "3.1") {
     expect_error(
       circuit_details <- load_circuit_details(2023, "bahrain"),
       "An old version of FastF1 is in use"

--- a/tests/testthat/test-load_circuit_details.R
+++ b/tests/testthat/test-load_circuit_details.R
@@ -14,7 +14,7 @@ test_that("load circuit details works", {
 
   # Ensure failure if old ff1, then skip
   ff1_ver <- get_fastf1_version()
-  if (ff1_ver$major < 3 | (ff1_ver$major == 3 & ff1_ver$minor < 1)) {
+  if (ff1_ver < '3.1') {
     expect_error(
       circuit_details <- load_circuit_details(2023, "bahrain"),
       "An old version of FastF1 is in use"

--- a/tests/testthat/test-load_driver_telemetry.R
+++ b/tests/testthat/test-load_driver_telemetry.R
@@ -15,7 +15,7 @@ test_that("driver telemetry", {
   # Tests
   # Ensure failure if old ff1, then skip
   ff1_ver <- get_fastf1_version()
-  if (ff1_ver$major < 3 | (ff1_ver$major == 3 & ff1_ver$minor < 1)) {
+  if (ff1_ver < '3.1') {
     expect_error(
       telem <- load_driver_telemetry(season = 2022, round = "Brazil", session = "S", driver = "HAM", laps = "all"),
       "An old version of FastF1 is in use"
@@ -28,7 +28,7 @@ test_that("driver telemetry", {
 
   expect_true(nrow(telem) > nrow(telem_fast))
   expect_true(ncol(telem) == ncol(telem_fast))
-  if (get_fastf1_version()$major >= 3) {
+  if (get_fastf1_version() > '3') {
     expect_equal(telem_fast$session_time[[1]], 3518.641)
     expect_equal(round(telem_fast$time[[2]], 3), 0.086)
   } # else {
@@ -40,7 +40,7 @@ test_that("driver telemetry", {
   #     "can only be a lap number if using fastf1 v3.0 or higher"
   #   )
   # }
-  if (get_fastf1_version()$major >= 3) {
+  if (get_fastf1_version() > '3') {
     telem_lap <- load_driver_telemetry(season = 2022, round = "Brazil", session = "S", driver = "HAM", laps = 1)
     expect_equal(telem_lap$time[[1]], 0)
     expect_equal(telem_lap$speed[[1]], 0)

--- a/tests/testthat/test-load_driver_telemetry.R
+++ b/tests/testthat/test-load_driver_telemetry.R
@@ -15,7 +15,7 @@ test_that("driver telemetry", {
   # Tests
   # Ensure failure if old ff1, then skip
   ff1_ver <- get_fastf1_version()
-  if (ff1_ver < '3.1') {
+  if (ff1_ver < "3.1") {
     expect_error(
       telem <- load_driver_telemetry(season = 2022, round = "Brazil", session = "S", driver = "HAM", laps = "all"),
       "An old version of FastF1 is in use"
@@ -28,7 +28,7 @@ test_that("driver telemetry", {
 
   expect_true(nrow(telem) > nrow(telem_fast))
   expect_true(ncol(telem) == ncol(telem_fast))
-  if (get_fastf1_version() > '3') {
+  if (get_fastf1_version() > "3") {
     expect_equal(telem_fast$session_time[[1]], 3518.641)
     expect_equal(round(telem_fast$time[[2]], 3), 0.086)
   } # else {
@@ -40,7 +40,7 @@ test_that("driver telemetry", {
   #     "can only be a lap number if using fastf1 v3.0 or higher"
   #   )
   # }
-  if (get_fastf1_version() > '3') {
+  if (get_fastf1_version() > "3") {
     telem_lap <- load_driver_telemetry(season = 2022, round = "Brazil", session = "S", driver = "HAM", laps = 1)
     expect_equal(telem_lap$time[[1]], 0)
     expect_equal(telem_lap$speed[[1]], 0)

--- a/tests/testthat/test-load_race_session.R
+++ b/tests/testthat/test-load_race_session.R
@@ -16,7 +16,7 @@ test_that("Load Session (file cached) Works", {
 
   # Ensure failure if old ff1, then skip
   ff1_ver <- get_fastf1_version()
-  if (ff1_ver < '3.1') {
+  if (ff1_ver < "3.1") {
     expect_error(
       session <- load_race_session(season = 2022, round = 1),
       "An old version of FastF1 is in use"
@@ -75,7 +75,7 @@ test_that("Load Session (memory cached) Works", {
 
   # Ensure failure if old ff1, then skip
   ff1_ver <- get_fastf1_version()
-  if (ff1_ver < '3.1') {
+  if (ff1_ver < "3.1") {
     expect_error(
       session <- load_race_session(season = 2022, round = 1),
       "An old version of FastF1 is in use"

--- a/tests/testthat/test-load_race_session.R
+++ b/tests/testthat/test-load_race_session.R
@@ -16,7 +16,7 @@ test_that("Load Session (file cached) Works", {
 
   # Ensure failure if old ff1, then skip
   ff1_ver <- get_fastf1_version()
-  if (ff1_ver$major < 3 | (ff1_ver$major == 3 & ff1_ver$minor < 1)) {
+  if (ff1_ver < '3.1') {
     expect_error(
       session <- load_race_session(season = 2022, round = 1),
       "An old version of FastF1 is in use"
@@ -75,7 +75,7 @@ test_that("Load Session (memory cached) Works", {
 
   # Ensure failure if old ff1, then skip
   ff1_ver <- get_fastf1_version()
-  if (ff1_ver$major < 3 | (ff1_ver$major == 3 & ff1_ver$minor < 1)) {
+  if (ff1_ver < '3.1') {
     expect_error(
       session <- load_race_session(season = 2022, round = 1),
       "An old version of FastF1 is in use"

--- a/tests/testthat/test-load_session_laps.R
+++ b/tests/testthat/test-load_session_laps.R
@@ -14,7 +14,7 @@ test_that("load session laps works", {
 
   # Ensure failure if old ff1, then skip
   ff1_ver <- get_fastf1_version()
-  if (ff1_ver$major < 3 | (ff1_ver$major == 3 & ff1_ver$minor < 1)) {
+  if (ff1_ver < '3.1') {
     expect_error(
       laps <- load_session_laps(season = 2022, round = "bahrain"),
       "An old version of FastF1 is in use"
@@ -33,7 +33,7 @@ test_that("load session laps works", {
   expect_equal(laps$time, laps2$time)
   expect_true(!is.na(laps$time[1]))
   expect_equal(nrow(laps), nrow(laps2))
-  if (get_fastf1_version()$major >= 3) {
+  if (get_fastf1_version() >= '3') {
     expect_true(all(lapsq$session_type %in% c("Q1", "Q2", "Q3")))
     expect_true(all(c("Q1", "Q2", "Q3") %in% unique(lapsq$session_type)))
   }

--- a/tests/testthat/test-load_session_laps.R
+++ b/tests/testthat/test-load_session_laps.R
@@ -14,7 +14,7 @@ test_that("load session laps works", {
 
   # Ensure failure if old ff1, then skip
   ff1_ver <- get_fastf1_version()
-  if (ff1_ver < '3.1') {
+  if (ff1_ver < "3.1") {
     expect_error(
       laps <- load_session_laps(season = 2022, round = "bahrain"),
       "An old version of FastF1 is in use"
@@ -33,7 +33,7 @@ test_that("load session laps works", {
   expect_equal(laps$time, laps2$time)
   expect_true(!is.na(laps$time[1]))
   expect_equal(nrow(laps), nrow(laps2))
-  if (get_fastf1_version() >= '3') {
+  if (get_fastf1_version() >= "3") {
     expect_true(all(lapsq$session_type %in% c("Q1", "Q2", "Q3")))
     expect_true(all(c("Q1", "Q2", "Q3") %in% unique(lapsq$session_type)))
   }

--- a/tests/testthat/test-plot_fastest.R
+++ b/tests/testthat/test-plot_fastest.R
@@ -24,7 +24,7 @@ test_that("graphics work", {
 
   # Ensure caught failure if old ff1, then skip remainder
   ff1_ver <- get_fastf1_version()
-  if (ff1_ver < '3.1') {
+  if (ff1_ver < "3.1") {
     expect_error(
       session <- load_race_session(season = 2022, round = 1),
       "An old version of FastF1 is in use"

--- a/tests/testthat/test-plot_fastest.R
+++ b/tests/testthat/test-plot_fastest.R
@@ -24,7 +24,7 @@ test_that("graphics work", {
 
   # Ensure caught failure if old ff1, then skip remainder
   ff1_ver <- get_fastf1_version()
-  if (ff1_ver$major < 3 | (ff1_ver$major == 3 & ff1_ver$minor < 1)) {
+  if (ff1_ver < '3.1') {
     expect_error(
       session <- load_race_session(season = 2022, round = 1),
       "An old version of FastF1 is in use"

--- a/vignettes/setup_fastf1.Rmd
+++ b/vignettes/setup_fastf1.Rmd
@@ -21,7 +21,7 @@ the Python package [`FastF1`](https://docs.fastf1.dev/). This guide may help res
 that might arise when you get the following warning or error messages:
 
 - `Ensure fastf1 python package is installed. Please run this to install the most recent version: setup_fastf1()`
-- `Error in if (get_fastf1_version()$major < 3) { :` 
+- `Error in if (get_fastf1_version() < '3.1') { :` 
    `missing value where TRUE/FALSE needed`
 
 If these happen to you (particularly if you're a new user of `f1dataR`) read on!


### PR DESCRIPTION
R has a built-in set of functions that better handle version numbers than the code we've put together. The `numeric_version()` and `package_version()` functions are part of base and allow for simple comparison between version numbers. For example:

```
ver <- package_version('3.2.1')

ver <= '3.1' 
[1] FALSE

ver > '3'
[1] TRUE
```

This PR converts our code to use the base functions.