### PR TITLE
Updated Ergast deprecation and a small API change handled

### DIFF
--- a/R/load_schedule.R
+++ b/R/load_schedule.R
@@ -19,8 +19,11 @@ load_schedule <- function(season = get_current_season()) {
     return(NULL)
   }
 
-  data <- data$MRData$RaceTable$Races %>%
-    dplyr::select(-"url")
+  data <- data$MRData$RaceTable$Races
+
+  if("url" %in% colnames(data)) {
+    data$url <- NULL
+  }
 
   if ("Circuit" %in% colnames(data)) {
     if (inherits(data$Circuit, "data.frame")) {


### PR DESCRIPTION
Jolpica no longer passes a 'url' in load_schedule (or doesn't currently because the races don't exist yet). Thie PR handles that better and improves the deprecation of Ergast with forced failover to Jolpica.